### PR TITLE
Introduce colorization, progress spinner and configurability of items on display.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lualine-lsp-progress
-Information provided by active lsp clients from the `$/progress` endpoint as a statusline componenet for [lualine.nvim](https://raw.githubusercontent.com/hoob3rt/lualine.nvim).
+Information provided by active lsp clients from the `$/progress` endpoint as a statusline component for [lualine.nvim](https://raw.githubusercontent.com/hoob3rt/lualine.nvim).
 
 ## Why?
 Some LSP servers take a while to initalize. This provides a nice visual indicator to show which clients are ready to use.
@@ -8,7 +8,7 @@ Some LSP servers take a while to initalize. This provides a nice visual indicato
 ![example](https://user-images.githubusercontent.com/56053130/115862312-b4b12c80-a3cf-11eb-9a0f-3cd67160d732.PNG)
 
 ## Use
-Add the componenet `lsp_progress` to one of your lualine sections.
+Add the component `lsp_progress` to one of your lualine sections.
 ```lua
 require'lualine'.setup{
 	...
@@ -29,4 +29,108 @@ Plug 'arkav/lualine-lsp-progress'
 ### [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use 'arkav/lualine-lsp-progress'
+```
+
+## Configuration
+
+### Configurable items
+* Items to display and order
+	* Lsp client name e.g. Rust
+	* Spinner
+	* Progress (individual actions undertaken by the LSP)
+		* Title of action undertaken by LSP e.g. Indexing
+		* Message from Lsp
+		* Percentage compplete
+* pre and post items - before each specific lsp item display text
+* Spinner
+	* Symbols
+	* Time between symbol update
+* Color of items
+* Last Message delay
+	* After we receive a progress message saying an action is complete __delay__ removing it from lualine so we can read that it's finished.
+	* After the final progress message is displayed __delay__ before no longer showing the lsp client name.
+
+### Decked out configuration
+```lua
+
+-- Color for highlights
+local colors = {
+  yellow = '#ECBE7B',
+  cyan = '#008080',
+  darkblue = '#081633',
+  green = '#98be65',
+  orange = '#FF8800',
+  violet = '#a9a1e1',
+  magenta = '#c678dd',
+  blue = '#51afef',
+  red = '#ec5f67'
+}
+
+local config = {
+  options = {
+    icons_enabled = true,
+    theme = 'gruvbox',
+    component_separators = {'', ''},
+    section_separators = {'', ''},
+    disabled_filetypes = {}
+  },
+  sections = {
+    lualine_a = {'mode'},
+    lualine_b = {'filename'},
+    lualine_c = {},
+    lualine_x = {},
+    lualine_y = {'encoding', 'fileformat', 'filetype'},
+    lualine_z = {'branch'},
+  },
+  inactive_sections = {
+    lualine_a = {},
+    lualine_b = {},
+    lualine_c = {'filename'},
+    lualine_x = {'location'},
+    lualine_y = {},
+    lualine_z = {}
+  },
+  tabline = {},
+  extensions = {}
+}
+
+
+-- Inserts a component in lualine_c at left section
+local function ins_left(component)
+  table.insert(config.sections.lualine_c, component)
+end
+
+-- Inserts a component in lualine_x ot right section
+local function ins_right(component)
+  table.insert(config.sections.lualine_x, component)
+end
+
+ins_left {
+	'lsp_progress',
+	display_components = { 'lsp_client_name', { 'title', 'percentage', 'message' }},
+	-- With spinner
+	-- display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' }},
+	colors = {
+	  percentage  = colors.cyan,
+	  title  = colors.cyan,
+	  message  = colors.cyan,
+	  spinner = colors.cyan,
+	  lsp_client_name = colors.magenta,
+	  use = true,
+	},
+	seperators = {
+		component = ' ',
+		progress = ' | ',
+		message = { pre = '(', post = ')'},
+		percentage = { pre = '', post = '%% ' },
+		title = { pre = '', post = ': ' },
+		lsp_client_name = { pre = '[', post = ']' },
+		spinner = { pre = '', post = '' },
+		message = { commenced = 'In Progress', completed = 'Completed' },
+	},
+	display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' } },
+	timer = { progress_enddelay = 500, spinner = 1000, lsp_client_name_enddelay = 1000 },
+	spinner_symbols = { '🌑 ', '🌒 ', '🌓 ', '🌔 ', '🌕 ', '🌖 ', '🌗 ', '🌘 ' },
+}
+
 ```

--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -3,7 +3,6 @@ local utils = require('lualine.utils.utils')
 
 local LspProgress = require('lualine.component'):new()
 
---print('Hello\n')
 -- LuaFormatter off
 LspProgress.default = {
 	colors = {
@@ -76,7 +75,6 @@ LspProgress.new = function(self, options, child)
 	  new_lsp_progress:setup_spinner()
   end
 
-  -- print(LspProgress.progress.message)
   return new_lsp_progress
 end
 
@@ -94,39 +92,29 @@ LspProgress.register_progress = function(self)
   	local val = msg.value
 	local client_id = tostring(client_id_int)
 
-	-- print(vim.inspect(msg))
 
   	if key then
 		if self.clients[client_id] == nil then
 			self.clients[client_id] = { progress = {}, name = vim.lsp.get_client_by_id(client_id_int).name }
-			--print('INITIALISE!!!!!!!!!!!!!!!!')
 		end
 		local progress_collection = self.clients[client_id].progress
 		if progress_collection[key] == nil then
-			--print(key)
-			--print(vim.inspect(progress_collection))
-			--print(vim.inspect(msg))
 			progress_collection[key] = { title = nil, message = nil, percentage = nil }
 		end
 
 		local progress = progress_collection[key]
-		--print("'" .. client_id .. "'")
-		--print(vim.inspect(progress_collection))
 
   		if val then
   			if val.kind == 'begin' then
 				progress.title = val.title
-				--print('"' .. key .. ': ' .. val.title .. '"')
   			end
 			if val.kind == 'report' then
-				--print('"progress: ' .. key .. '.. ' .. vim.inspect(progress) .. '"')
 				if val.percentage then
 					progress.percentage = val.percentage
 				end
 				if val.message then
 					progress.message = val.message
 				end
-				--print('"progress: ' .. key .. '.. ' .. vim.inspect(progress) .. '"')
   			end
 			if val.kind == 'end' then
 				if progress.percentage then
@@ -134,7 +122,6 @@ LspProgress.register_progress = function(self)
 					progress.message = 'Completed'
 				end
 				vim.defer_fn(function() 
-					--print('Removing: "' .. key .. '"')
 					if self.clients[client_id] then
 						self.clients[client_id].progress[key] = nil
 					end
@@ -151,7 +138,6 @@ LspProgress.register_progress = function(self)
 				end, self.options.timer.progress_enddelay)
 			end
   		end
-		--print(vim.inspect(msg))
   	end
   end
 
@@ -199,7 +185,6 @@ LspProgress.update_progress_components = function(self, result, display_componen
 	local p = {}
 	local options = self.options
 	for _, progress in pairs(client_progress) do
-		--print(vim.inspect(progress) .. '\n\r')
 		if progress.title then
 			for _, i in pairs(display_components) do
 				if progress[i] then
@@ -213,7 +198,6 @@ LspProgress.update_progress_components = function(self, result, display_componen
 			table.insert(result, table.concat(p, ''))
 		end
 	end
---	print(vim.inspect(progress))
 end
 
 

--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -167,18 +167,18 @@ LspProgress.update_progress = function(self)
 		for _, display_component in pairs(self.options.display_components) do
 			if display_component == 'lsp_client_name' and options.display_lsp_client_name then
 				if options.colors.use then
-					table.insert(result, highlight.component_format_highlight(self.highlights.lsp_client_name) .. client.name)
+					table.insert(result, highlight.component_format_highlight(self.highlights.lsp_client_name) .. options.seperators.lsp_client_name.pre .. client.name .. options.seperators.lsp_client_name.post)
 				else
-					table.insert(result, client.name)
+					table.insert(result, options.seperators.lsp_client_name.pre .. client.name .. options.seperators.lsp_client_name.post)
 				end
 			end
 			if display_component == 'spinner' and options.display_spinner then
 				local progress = client.progress
 				for _, _ in pairs(progress) do
 					if options.colors.use then
-						table.insert(result, highlight.component_format_highlight(self.highlights.spinner) .. self.spinner.symbol)
+						table.insert(result, highlight.component_format_highlight(self.highlights.spinner) .. options.seperators.spinner.pre .. self.spinner.symbol .. options.seperators.spinner.post)
 					else
-						table.insert(result, self.spinner.symbol)
+						table.insert(result, options.seperators.spinner.pre .. self.spinner.symbol .. options.seperators.spinner.post)
 					end
 					break
 				end

--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -22,8 +22,6 @@ LspProgress.default = {
 		spinner = { pre = '', post = '' },
 	},
 	display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' } },
-	display_spinner = true,
-	display_lsp_client_name = true,
 	timer = { progress_enddelay = 500, spinner = 1000, lsp_client_name_enddelay = 1000 },
 	--spinner_symbols_spinner = { '-', '/', '|', "\\" },
 	spinner_symbols = { ' ', ' ', ' ', ' ', ' ', ' ' },
@@ -37,14 +35,11 @@ LspProgress.new = function(self, options, child)
 										new_lsp_progress.options.colors or {})
   new_lsp_progress.options.seperators = vim.tbl_extend('force', LspProgress.default.seperators, 
 										new_lsp_progress.options.seperators or {})
-  new_lsp_progress.options.display_components = vim.tbl_extend('force', LspProgress.default.display_components, 
-										new_lsp_progress.options.display_components or {})
+  new_lsp_progress.options.display_components = new_lsp_progress.options.display_components or LspProgress.default.display_components
   new_lsp_progress.options.timer = vim.tbl_extend('force', LspProgress.default.timer, 
 										new_lsp_progress.options.timer or {})
   new_lsp_progress.options.spinner_symbols = vim.tbl_extend('force', LspProgress.default.spinner_symbols, 
 										new_lsp_progress.options.spinner_symbols or {})
-  new_lsp_progress.options.display_spinner = new_lsp_progress.options.display_spinner or LspProgress.default.display_spinner
-  new_lsp_progress.options.display_lsp_client_name = new_lsp_progress.options.display_lsp_client_name or LspProgress.default.display_lsp_client_name
 
   new_lsp_progress.highlights = { percentage = '', title = '', message = '' }
   if new_lsp_progress.options.colors.use then
@@ -71,8 +66,11 @@ LspProgress.new = function(self, options, child)
 
   new_lsp_progress:register_progress()
   -- No point in setting spinner callbacks if it is not displayed.
-  if new_lsp_progress.options.display_spinner then
-	  new_lsp_progress:setup_spinner()
+  for _, display_component in pairs(new_lsp_progress.options.display_components) do
+	  if display_component == 'spinner' then
+		  new_lsp_progress:setup_spinner()
+		  break
+	  end
   end
 
   return new_lsp_progress
@@ -151,14 +149,14 @@ LspProgress.update_progress = function(self)
 
 	for _, client in pairs(self.clients) do
 		for _, display_component in pairs(self.options.display_components) do
-			if display_component == 'lsp_client_name' and options.display_lsp_client_name then
+			if display_component == 'lsp_client_name' then
 				if options.colors.use then
 					table.insert(result, highlight.component_format_highlight(self.highlights.lsp_client_name) .. options.seperators.lsp_client_name.pre .. client.name .. options.seperators.lsp_client_name.post)
 				else
 					table.insert(result, options.seperators.lsp_client_name.pre .. client.name .. options.seperators.lsp_client_name.post)
 				end
 			end
-			if display_component == 'spinner' and options.display_spinner then
+			if display_component == 'spinner' then
 				local progress = client.progress
 				for _, _ in pairs(progress) do
 					if options.colors.use then

--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -1,51 +1,221 @@
--- displays the status of active lsp clients
+local highlight = require('lualine.highlight')
+local utils = require('lualine.utils.utils')
+
 local LspProgress = require('lualine.component'):new()
-local _clients = {}
-local _status = ''
-local function _update()
-	local status = ''
-	for i, client in ipairs(_clients) do
-		status = status .. '[' .. client.name .. '] '
-		for j, task in pairs(client.tasks) do
-			status = status .. task.title	
-			if task.percentage then status = status .. ' ' .. task.percentage .. '%%' end
-			if task.message then status = status .. ' ' .. task.message end
-		end
-		if i < #_clients then status = status .. ',' end
-	end
-	return status
+
+--print('Hello\n')
+-- LuaFormatter off
+LspProgress.default = {
+	colors = {
+	  percentage  = '#ffffff',
+	  title  = '#ffffff',
+	  message  = '#ffffff',
+	  spinner = '#008080',
+	  lsp_client_name = '#c678dd',
+	  use = true,
+	},
+	seperators = {
+		seperator = ' | ',
+		message = { pre = '(', post = ')'},
+		percentage = { pre = '', post = '%% ' },
+		title = { pre = '', post = ': ' },
+		lsp_client_name = { pre = '[', post = ']' },
+		spinner = { pre = '', post = '' },
+	},
+	display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' } },
+	display_spinner = true,
+	display_lsp_client_name = true,
+	timer = { enddelay = 500, spinner = 1000 },
+	--spinner_symbols_spinner = { '-', '/', '|', "\\" },
+	spinner_symbols = { ' ', ' ', ' ', ' ', ' ', ' ' },
+}
+
+-- Initializer
+LspProgress.new = function(self, options, child)
+  local new_lsp_progress = self._parent:new(options, child or LspProgress)
+
+  new_lsp_progress.options.colors = vim.tbl_extend('force', LspProgress.default.colors, 
+										new_lsp_progress.options.colors or {})
+  new_lsp_progress.options.seperators = vim.tbl_extend('force', LspProgress.default.seperators, 
+										new_lsp_progress.options.seperators or {})
+  new_lsp_progress.options.display_components = vim.tbl_extend('force', LspProgress.default.display_components, 
+										new_lsp_progress.options.display_components or {})
+  new_lsp_progress.options.timer = vim.tbl_extend('force', LspProgress.default.timer, 
+										new_lsp_progress.options.timer or {})
+  new_lsp_progress.options.spinner_symbols = vim.tbl_extend('force', LspProgress.default.spinner_symbols, 
+										new_lsp_progress.options.spinner_symbols or {})
+  new_lsp_progress.options.display_spinner = new_lsp_progress.options.display_spinner or LspProgress.default.display_spinner
+  new_lsp_progress.options.display_lsp_client_name = new_lsp_progress.options.display_lsp_client_name or LspProgress.default.display_lsp_client_name
+
+  new_lsp_progress.highlights = { percentage = '', title = '', message = '' }
+  if new_lsp_progress.options.colors.use then
+    new_lsp_progress.highlights.title = highlight.create_component_highlight_group(
+	  { fg = new_lsp_progress.options.colors.title }, 'lspprogress_title', new_lsp_progress.options
+    )
+    new_lsp_progress.highlights.percentage = highlight.create_component_highlight_group(
+	  { fg = new_lsp_progress.options.colors.percentage }, 'lspprogress_percentage', new_lsp_progress.options
+    )
+    new_lsp_progress.highlights.message = highlight.create_component_highlight_group(
+	  { fg = new_lsp_progress.options.colors.message }, 'lspprogress_message', new_lsp_progress.options
+    )
+    new_lsp_progress.highlights.spinner = highlight.create_component_highlight_group(
+	  { fg = new_lsp_progress.options.colors.spinner }, 'lspprogress_spinner', new_lsp_progress.options
+    )
+    new_lsp_progress.highlights.lsp_client_name = highlight.create_component_highlight_group(
+	  { fg = new_lsp_progress.options.colors.lsp_client_name }, 'lspprogress_lsp_client_name', new_lsp_progress.options
+    )
+  end
+
+
+
+  -- Setup callback to get updates from the lsp to update lualine.
+
+  new_lsp_progress:register_progress()
+  -- No point in setting spinner callbacks if it is not displayed.
+  if new_lsp_progress.options.display_spinner then
+	  new_lsp_progress:setup_spinner()
+  end
+
+  -- print(LspProgress.progress.message)
+  return new_lsp_progress
 end
-local function progress_callback(_, _, msg, client_id) 
-	local val = msg.value
-	if val.kind then 
-		if val.kind == 'begin' then
-			if not _clients[client_id] then
-				_clients[client_id]= {
-					name = vim.lsp.get_client_by_id(client_id).name,
-					tasks = {}
-				}
+
+LspProgress.update_status = function(self)
+	self:update_progress()
+	return self.progress_message
+end
+
+
+LspProgress.register_progress = function(self)
+  self.clients = {}
+  self.progress_callback = function (_, _, msg, client_id)
+  	local key = msg.token
+  	local val = msg.value
+
+	-- print(vim.inspect(msg))
+
+  	if key then
+		if self.clients[client_id] == nil then
+			self.clients[client_id] = { progress = {}, name = vim.lsp.get_client_by_id(client_id).name }
+		end
+		local progress_collection = self.clients[client_id].progress
+		if progress_collection[key] == nil then
+			progress_collection[key] = { title = nil, message = nil, percentage = nil }
+		end
+
+		local progress = progress_collection[key]
+
+		--print(vim.inspect(progress))
+
+  		if val then
+  			if val.kind == 'begin' then
+				progress.title = val.title
+  			end
+			if val.kind == 'report' then
+				if val.percentage then
+					progress.percentage = val.percentage
+				end
+				if val.message then
+					progress.message = val.message
+				end
+  			end
+			if val.kind == 'end' then
+				if progress.percentage then
+					progress.percentage = '100'
+					progress.message = 'Completed'
+				end
+				vim.defer_fn(function() 
+					if self.clients[client_id] then
+						self.clients[client_id].progress[key] = nil
+						self:update_progress()
+						vim.defer_fn(function()
+							if self.clients[client_id] and #self.clients[client_id].progress == 0 then
+								self.clients[client_id] = nil
+							end
+						end, 1000)
+					end
+				end, self.options.timer.enddelay)
 			end
-			_clients[client_id].tasks[msg.token] = {
-				title = val.title,
-				message = val.message,
-				percentage = val.percentage
-			}
-			_status = _update()
-		elseif val.kind == 'report' and _clients[client_id] then
-			_clients[client_id].tasks[msg.token].message = val.message
-			_clients[client_id].tasks[msg.token].percentage = val.percentage
-			_status = _update()
-		elseif val.kind == 'end' then
-			_clients[client_id].tasks[msg.token] = nil
-			_status = _update()
-		end
-	end 
+  		end
+		self:update_progress()
+		--print(vim.inspect(msg))
+  	end
+  end
+
+  vim.lsp.handlers["$/progress"] = self.progress_callback
 end
 
-vim.lsp.handlers['$/progress'] = progress_callback
+LspProgress.update_progress = function(self)
+	local options = self.options
+	local result = {}
 
-LspProgress.update_status = function()
-	return _status
+
+	for _, client in pairs(self.clients) do
+		for _, display_component in pairs(self.options.display_components) do
+			if display_component == 'lsp_client_name' then
+				if options.display_lsp_client_name then
+					if options.colors.use then
+						table.insert(result, highlight.component_format_highlight(self.highlights.lsp_client_name) .. client.name)
+					else
+						table.insert(result, client.name)
+					end
+				end
+			end
+			if display_component == 'spinner' then
+				if options.colors.use then
+					table.insert(result, highlight.component_format_highlight(self.highlights.spinner) .. self.spinner.symbol)
+				else
+					table.insert(result, self.spinner.symbol)
+				end
+			end
+			if type(display_component) == "table" then
+				self:update_progress_components(result, display_component, client.progress)
+			end
+		end
+	end
+	if #result > 1 or (#result > 0 and self.spinner == false) then
+		self.progress_message = table.concat(result, options.seperators.seperator)
+	else
+		self.progress_message = ''
+	end
+end
+
+LspProgress.update_progress_components = function(self, result, display_components, client_progress)
+		local p = {}
+		local options = self.options
+		for _, progress in pairs(client_progress) do
+			if progress.title then
+				for _, i in pairs(display_components) do
+					if progress[i] then
+						if options.colors.use then
+							table.insert(p, highlight.component_format_highlight(self.highlights[i]) .. options.seperators[i].pre .. progress[i] .. options.seperators[i].post)
+						else 
+							table.insert(p, options.seperators[i].pre .. progress[i] .. options.seperators[i].post)
+						end
+					end
+				end
+				table.insert(result, table.concat(p, ''))
+			end
+		end
+--	print(vim.inspect(progress))
+end
+
+
+LspProgress.setup_spinner = function(self)
+	self.spinner = {}
+	self.spinner.index = 0
+	self.spinner.symbol_mod = #self.options.spinner_symbols
+	self.spinner.symbol = self.options.spinner_symbols[1]
+	local timer = vim.loop.new_timer()
+	timer:start(0, self.options.timer.spinner,
+	function()
+	--	print('Spinner\n\r')
+	--	print(LspProgress.spinner.index .. '\n\r')
+		self.spinner.index = (self.spinner.index % self.spinner.symbol_mod) + 1
+	--	print(LspProgress.spinner.index .. '\n\r')
+		self.spinner.symbol = self.options.spinner_symbols[self.spinner.index]
+	--	print(LspProgress.spinner.index .. ': ' .. LspProgress.spinner.symbol .. '\n\r')
+	end)
 end
 
 return LspProgress


### PR DESCRIPTION
Hi arkav,

I have introduced some additional features.
* A spinner (set on a timer)
* Initial message text for when the message of __kind is begin__ is provided (I've set this to In progress)
* Completion message for when the __kind is end__ (I've set this to Completed) (and percentage to 100 if it was previously set).
*  Message delays - Show completion messages for a short period before making them disappear. (So you can read when a particular progress item has finished)
* Pre and post text to wrap around the title, messages and percentages from the Lsp. This is so we can wrap text or put in a percentage sign.
*  Configure so the items and the order of the items displayed may be configured

I believe the default configuration should display much the same as what you initially had. Let me know what you think.
Feel free to rebase or squash the changes to fit with our preferred style for keeping with a repository up to date.

I've also updated the README.md, to provide a good understanding of the configuration options available. 

Feel free to rebase or squash the changes.

Cheers,

Garrick