### PR TITLE
Bug Fix - Stop null Reference Exception in rare occurances

### DIFF
--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -132,9 +132,11 @@ LspProgress.register_progress = function(self)
 					end
 					vim.defer_fn(function()
 						local has_items = false
-						for _, _ in pairs(self.clients[client_id].progress) do
-							has_items = 1
-							break
+						if self.clients[client_id] and self.clients[client_id].progress then
+							for _, _ in pairs(self.clients[client_id].progress) do
+								has_items = 1
+								break
+							end
 						end
 						if has_items == false then
 							self.clients[client_id] = nil


### PR DESCRIPTION
A race condition can be triggered in some instances that may cause a null reference in some circumstances.

Guard clause to stop prevent this error.