### PR TITLE
fix: caught a few issues in the README-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ end
 
 ins_left {
 	'lsp_progress',
-	display_components = { 'lsp_client_name', { 'title', 'percentage', 'message' }},
-	-- With spinner
-	-- display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' }},
 	colors = {
 	  percentage  = colors.cyan,
 	  title  = colors.cyan,
@@ -126,11 +123,11 @@ ins_left {
 		title = { pre = '', post = ': ' },
 		lsp_client_name = { pre = '[', post = ']' },
 		spinner = { pre = '', post = '' },
-		message = { commenced = 'In Progress', completed = 'Completed' },
 	},
 	display_components = { 'lsp_client_name', 'spinner', { 'title', 'percentage', 'message' } },
 	timer = { progress_enddelay = 500, spinner = 1000, lsp_client_name_enddelay = 1000 },
 	spinner_symbols = { '🌑 ', '🌒 ', '🌓 ', '🌔 ', '🌕 ', '🌖 ', '🌗 ', '🌘 ' },
+	message = { commenced = 'In Progress', completed = 'Completed' },
 }
 
 ```


### PR DESCRIPTION
This change makes the example config match the format used in `LspProgress.default` again.

Addendum: Since the commit diff doesn't show the changes as clearly as I expected:
- moved the duplicate message attribute out of the separators-table
- removed the duplicate display_components and kept the one that invokes the spinner