### PR TITLE
Fix spinner not updating

### DIFF
--- a/lua/lualine/components/lsp_progress.lua
+++ b/lua/lualine/components/lsp_progress.lua
@@ -211,10 +211,10 @@ LspProgress.setup_spinner = function(self)
 	self.spinner.symbol = self.options.spinner_symbols[1]
 	local timer = vim.loop.new_timer()
 	timer:start(0, self.options.timer.spinner,
-	function()
+	vim.schedule_wrap(function()
 		self.spinner.index = (self.spinner.index % self.spinner.symbol_mod) + 1
 		self.spinner.symbol = self.options.spinner_symbols[self.spinner.index]
-	end)
+	end))
 end
 
 return LspProgress


### PR DESCRIPTION
https://github.com/arkav/lualine-lsp-progress/issues/15

I ran into this same issue... looks like the timer wasn't implemented correctly and so the spinner was relying on status updates.

Wrapping the function in a `vim.schedule_wrap` appears to fix the problem